### PR TITLE
Support multiple UPS instances and per-UPS systemd services (Debian 12+)

### DIFF
--- a/nut/map.jinja
+++ b/nut/map.jinja
@@ -39,3 +39,16 @@
 {%-   set macos_group = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
 {%-   do nut.update({'group': macos_group}) %}
 {%- endif %}
+
+{# On récupère l'unité UPS définie dans les pillars #}
+{%- set ups_units = salt['pillar.get']('nut:server:ups:config:units', {}) %}
+{%- set ups_keys = ups_units.keys() | list %}
+{%- set first_ups = ups_keys[0] if ups_keys | length > 0 else 'unknown' %}
+
+nut:
+  server:
+    ups:
+      service:
+        name: nut-driver@{{ first_ups }}
+        enabled: true
+      instance: {{ first_ups }}

--- a/nut/map.jinja
+++ b/nut/map.jinja
@@ -40,11 +40,22 @@
 {%-   do nut.update({'group': macos_group}) %}
 {%- endif %}
 
-{# On récupère l'unité UPS définie dans les pillars #}
+
+{# BEGIN of post-processing for Debian >=12 nut-driver@ups #}
+{%- set os_ver = grains.get('osrelease', '0') | int %}
 {%- set ups_units = salt['pillar.get']('nut:server:ups:config:units', {}) %}
 {%- set ups_keys = ups_units.keys() | list %}
 {%- set first_ups = ups_keys[0] if ups_keys | length > 0 else 'unknown' %}
 
+{%- if os_ver < 12 %}
+nut:
+  server:
+    ups:
+      service:
+        name: nut-driver
+        enabled: true
+      instance: ''
+{%- else %}
 nut:
   server:
     ups:
@@ -52,3 +63,5 @@ nut:
         name: nut-driver@{{ first_ups }}
         enabled: true
       instance: {{ first_ups }}
+{%- endif %}
+{# END of post-processing for Debian >=12 nut-driver@ups #}

--- a/nut/map.jinja
+++ b/nut/map.jinja
@@ -41,27 +41,24 @@
 {%- endif %}
 
 
-{# BEGIN of post-processing for Debian >=12 nut-driver@ups #}
+{# BEGIN: Post-processing for multi-UPS + Debian 10/12 nut-driver@ups #}
 {%- set os_ver = grains.get('osrelease', '0') | int %}
 {%- set ups_units = salt['pillar.get']('nut:server:ups:config:units', {}) %}
 {%- set ups_keys = ups_units.keys() | list %}
-{%- set first_ups = ups_keys[0] if ups_keys | length > 0 else 'unknown' %}
 
 {%- if os_ver < 12 %}
-nut:
-  server:
-    ups:
-      service:
-        name: nut-driver
-        enabled: true
-      instance: ''
+  {# Debian 10 : one service only nut-driver #}
+  {%- do nut.setdefault('server', {}).setdefault('ups', {}).update({
+        'services': [{'name': 'nut-driver', 'enabled': True}]
+      }) %}
 {%- else %}
-nut:
-  server:
-    ups:
-      service:
-        name: nut-driver@{{ first_ups }}
-        enabled: true
-      instance: {{ first_ups }}
+  {# Debian 12+ : un service par UPS #}
+  {%- set services = [] %}
+  {%- for ups in ups_keys %}
+    {%- do services.append({'name': 'nut-driver@' ~ ups, 'enabled': True}) %}
+  {%- endfor %}
+  {%- do nut.setdefault('server', {}).setdefault('ups', {}).update({
+        'services': services
+      }) %}
 {%- endif %}
-{# END of post-processing for Debian >=12 nut-driver@ups #}
+{# END: Post-processing for multi-UPS + Debian 10/12 nut-driver@ups #}

--- a/nut/server/service/running.sls
+++ b/nut/server/service/running.sls
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-{% import_yaml "nut/map.jinja" as nutmap %}
+{%- from "nut/map.jinja" import nut as nutmap with context %}
 
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
@@ -19,17 +19,19 @@ include:
   - {{ sls_server_config_upsd }}
   - {{ sls_server_config_users }}
 
-nut-server-service-running-ups-service-running:
+{%- for svc in nutmap.server.ups.services %}
+nut-server-service-running-ups-service-running-{{ loop.index }}:
   service.running:
-    - name: {{ nutmap.nut.server.ups.service.name }}
-    - enable: {{ nutmap.nut.server.ups.service.enabled }}
+    - name: {{ svc.name }}
+    - enable: {{ svc.enabled }}
     - watch:
       - sls: {{ sls_server_config_mode }}
       - sls: {{ sls_server_config_ups }}
       - sls: {{ sls_server_config_upsd }}
       - sls: {{ sls_server_config_users }}
     # If the mode is 'none' we respect the package and do nothing
-    - unless: test "{{ nut.mode }}" = "none"
+    - unless: test "{{ nutmap.mode }}" = "none"
+{%- endfor %}
 
 nut-server-service-running-upsd-service-running:
   service.running:

--- a/nut/server/service/running.sls
+++ b/nut/server/service/running.sls
@@ -1,6 +1,15 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
+{% import_yaml "nut/map.jinja" as nutmap %}
+
+log-nut-instance:
+  module.run:
+    - name: cmd.run
+    - cmd: >
+        echo "DEBUG: nut-driver instance = {{ nutmap.nut.server.ups.instance }}, service = {{ nutmap.nut.server.ups.service.name }}"
+
+
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_config_file = tplroot ~ '.config.file' %}
@@ -19,8 +28,8 @@ include:
 
 nut-server-service-running-ups-service-running:
   service.running:
-    - name: {{ nut.server.ups.service.name }}
-    - enable: {{ nut.server.ups.service.enabled }}
+    - name: {{ nutmap.nut.server.ups.service.name }}
+    - enable: {{ nutmap.nut.server.ups.service.enabled }}
     - watch:
       - sls: {{ sls_server_config_mode }}
       - sls: {{ sls_server_config_ups }}

--- a/nut/server/service/running.sls
+++ b/nut/server/service/running.sls
@@ -3,13 +3,6 @@
 
 {% import_yaml "nut/map.jinja" as nutmap %}
 
-log-nut-instance:
-  module.run:
-    - name: cmd.run
-    - cmd: >
-        echo "DEBUG: nut-driver instance = {{ nutmap.nut.server.ups.instance }}, service = {{ nutmap.nut.server.ups.service.name }}"
-
-
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {%- set sls_config_file = tplroot ~ '.config.file' %}


### PR DESCRIPTION
This PR adds support for systems with multiple UPS units configured via pillars. 

It adjusts the `map.jinja` logic to generate one systemd `nut-driver@<ups>` service per UPS instance on Debian 12+, where the packaging now uses per-unit services. 

For compatibility, systems running Debian <=11 continue to use the legacy `nut-driver` service.

The `service.running` logic in `nut/server/service/running.sls` has been updated to loop over all generated services for multi-UPS setups.

Tested on:
- Debian 10 (legacy `nut-driver`)
- Debian 12 (multi-UPS with `nut-driver@<ups>`)

This change ensures backward compatibility with existing setups while aligning with systemd service changes in newer distributions.



